### PR TITLE
Add JWT token process logic to SocialReview Comment API

### DIFF
--- a/socialreview/common/models/review.js
+++ b/socialreview/common/models/review.js
@@ -28,7 +28,9 @@ module.exports = function(Review) {
       next();
     });
 
-    Review.beforeRemote('post', function(ctx, report, next){
+    // Set the JWT Token to the backend POST function
+    // But the hook point is on the comment API
+    Review.beforeRemote('comment', function(ctx, report, next){
       var ds = Review.getDataSource(),
       listOperation = ds.settings.operations[1],
       headers = listOperation.template.headers;

--- a/socialreview/common/models/review.js
+++ b/socialreview/common/models/review.js
@@ -3,15 +3,6 @@ module.exports = function(Review) {
   Review.comment = function(comment, itemId, rating, reviewer_email, reviewer_name, review_date, cb) {
 
 
-    //var reviewService = Review.app.dataSources.review;
-
-    // Pass the JWT Authorization header
-    //Review.beforeRemote('comment', function(ctx, report, next){
-    //  ctx.jwttoken = ctx.req.headers.Authorization;
-    //  console.log("AUthorization Header: " + ctx.jwttoken);
-    //  next();
-    //});
-
     Review.post(comment, itemId, rating, reviewer_email, reviewer_name, review_date, function(err, response, context) {
       if (err) throw err; //error making request
       if (response.error) {
@@ -32,6 +23,14 @@ module.exports = function(Review) {
     Review.beforeRemote('list', function(ctx, report, next){
       var ds = Review.getDataSource(),
       listOperation = ds.settings.operations[0],
+      headers = listOperation.template.headers;
+      headers['Authorization'] = ctx.req.headers.authorization;
+      next();
+    });
+
+    Review.beforeRemote('post', function(ctx, report, next){
+      var ds = Review.getDataSource(),
+      listOperation = ds.settings.operations[1],
       headers = listOperation.template.headers;
       headers['Authorization'] = ctx.req.headers.authorization;
       next();

--- a/socialreview/server/datasources.json
+++ b/socialreview/server/datasources.json
@@ -32,6 +32,7 @@
           "method": "POST",
           "options": {
             "headers": {
+              "Authorization": "",
               "accept": "application/json",
               "content-type": "application/json"
             },

--- a/socialreview/server/datasources.json
+++ b/socialreview/server/datasources.json
@@ -30,12 +30,12 @@
       {
         "template": {
           "method": "POST",
+          "headers": {
+            "Authorization": "",
+            "accept": "application/json",
+            "content-type": "application/json"
+          },
           "options": {
-            "headers": {
-              "Authorization": "",
-              "accept": "application/json",
-              "content-type": "application/json"
-            },
             "strictSSL": false
           },
           "url": "https://netflix-zuul-cloudnative-dev.mybluemix.net/socialreview-microservice/micro/review",


### PR DESCRIPTION
Add JWT token process logic to SocialReview Comment API
This will block any calls to SocialReview Microservices, only allow Zuul proxy with verified JWT token.
